### PR TITLE
preparing use Cloud Datastore Emulator backend in go111 runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ ENV NODEJS_VERSION v10
 RUN mkdir /work
 WORKDIR /work
 
+# for Cloud Datastore Emulator: openjdk-11-jre-headless
+#   https://issuetracker.google.com/issues/119212211
+
 RUN apt-get update && \
     ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
     apt-get install -y --no-install-recommends \
@@ -18,7 +21,8 @@ RUN apt-get update && \
         curl ca-certificates \
         build-essential git unzip \
         ssh \
-        python && \
+        python \
+        openjdk-11-jre-headless && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -30,7 +34,7 @@ RUN curl -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/r
     ./google-cloud-sdk/install.sh --quiet && \
     gcloud --quiet components install app-engine-go && \
     chmod +x /work/google-cloud-sdk/platform/google_appengine/goapp /work/google-cloud-sdk/platform/google_appengine/appcfg.py
-# RUN gcloud --quiet components install docker-credential-gcr kubectl alpha beta
+# RUN gcloud --quiet components install cloud-datastore-emulator docker-credential-gcr kubectl alpha beta
 
 # setup go environment
 ENV PATH=$PATH:/go/bin:/usr/local/go/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer="vvakame@gmail.com"
 # GAE/Go build & testing environment for Circle CI 2.0
 
 ENV GCLOUD_SDK_VERSION 224.0.0
+# same as google-cloud-sdk/platform/google_appengine/lib/grpcio-X.X.X
+ENV PIP_GRPCIO_VERSION 1.9.1
 ENV GOLANG_VERSION 1.11.2
 ENV DEP_VERSION 0.5.0
 ENV NODEJS_VERSION v10
@@ -11,7 +13,7 @@ ENV NODEJS_VERSION v10
 RUN mkdir /work
 WORKDIR /work
 
-# for Cloud Datastore Emulator: openjdk-11-jre-headless
+# for Cloud Datastore Emulator: openjdk-11-jre-headless python-pip
 #   https://issuetracker.google.com/issues/119212211
 
 RUN apt-get update && \
@@ -22,9 +24,12 @@ RUN apt-get update && \
         build-essential git unzip \
         ssh \
         python \
-        openjdk-11-jre-headless && \
+        openjdk-11-jre-headless python-pip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# for Cloud Datastore Emulator: grpcio
+RUN pip install grpcio==${PIP_GRPCIO_VERSION}
 
 # setup Google Cloud SDK & GAE/Go Environment
 ENV PATH=/work/google-cloud-sdk/bin:/work/google-cloud-sdk/platform/google_appengine:$PATH

--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ Circle CI 2.0 official image are only for 1 language.
 
 * GOPATH `/go`
 * Work space of tools setup `/work`
+
+## NOTE for go111 runtime testing
+
+If you want to use Cloud Datastore Emulator instead of Old SQLite Datastore backend.
+https://issuetracker.google.com/issues/119212211
+
+```
+$ gcloud config set disable_usage_reporting true
+```


### PR DESCRIPTION
NOTE: https://issuetracker.google.com/issues/119212211

https://gcpug.slack.com/archives/C0D60LCAE/p1541580973212700
https://gcpug.slack.com/archives/C0D60LCAE/p1541647056223800

```
$ gcloud config set disable_usage_reporting true
```
🤔 ❓ 

platform/google_appengine/google/appengine/tools/devappserver2/devappserver2.py
